### PR TITLE
[Feature] - isDefaultValue on Setting Object.

### DIFF
--- a/src/Setting.php
+++ b/src/Setting.php
@@ -13,6 +13,7 @@ class Setting
     private $value;
     private $type = '';
     private $options = [];
+    private $isDefaultValue = true;
 
     /**
      * Create a new Setting object
@@ -46,6 +47,27 @@ class Setting
     public function setValue($value): void
     {
         $this->value = $value;
+    }
+
+    /**
+     * Set whether the value is Default or not for this setting
+     * @param boolean
+     *
+     * @return void
+     */
+    public function setIsDefaultValue($isDefaultValue): void
+    {
+        $this->isDefaultValue = $isDefaultValue;
+    }
+
+    /**
+     * Get whether the value is the Default value or not
+     *
+     * @return bool
+     */
+    public function getIsDefaultValue(): bool
+    {
+        return $this->isDefaultValue;
     }
 
     /**

--- a/src/Utilities/SettingFactory.php
+++ b/src/Utilities/SettingFactory.php
@@ -38,6 +38,7 @@ class SettingFactory
 
         if (!is_null($value)) {
             $setting->setValue($value->value);
+            $setting->setIsDefaultValue(false);
         }
 
         return $setting;

--- a/tests/Integration/Utilities/SettingFactoryTest.php
+++ b/tests/Integration/Utilities/SettingFactoryTest.php
@@ -21,6 +21,7 @@ class SettingFactoryTest extends TestCase
         $this->assertSame('key', $setting->getKey());
         $this->assertSame('default', $setting->getValue());
         $this->assertSame('identifier', $setting->getIdentifier());
+        $this->assertTrue($setting->getIsDefaultValue());
     }
 
     /**
@@ -39,5 +40,6 @@ class SettingFactoryTest extends TestCase
         $this->assertSame('key', $setting->getKey());
         $this->assertSame('override', $setting->getValue());
         $this->assertSame('identifier', $setting->getIdentifier());
+        $this->assertFalse($setting->getIsDefaultValue());
     }
 }

--- a/tests/Integration/Utilities/SettingsFactoryTest.php
+++ b/tests/Integration/Utilities/SettingsFactoryTest.php
@@ -67,7 +67,7 @@ class SettingsFactoryTest extends TestCase
         $this->assertSame('k2', $settings->get('k2')->getKey());
         $this->assertSame('v2', $settings->get('k2')->getValue());
         $this->assertSame('1', $settings->get('k2')->getIdentifier());
-        $this->assertTrue($settings->get('k1')->getIsDefaultValue());
+        $this->assertTrue($settings->get('k2')->getIsDefaultValue());
     }
 
     /**

--- a/tests/Integration/Utilities/SettingsFactoryTest.php
+++ b/tests/Integration/Utilities/SettingsFactoryTest.php
@@ -31,9 +31,11 @@ class SettingsFactoryTest extends TestCase
         $this->assertSame('k1', $settings->get('k1')->getKey());
         $this->assertSame('v1', $settings->get('k1')->getValue());
         $this->assertSame('1', $settings->get('k1')->getIdentifier());
+        $this->assertTrue($settings->get('k1')->getIsDefaultValue());
         $this->assertSame('k2', $settings->get('k2')->getKey());
         $this->assertSame('v2', $settings->get('k2')->getValue());
         $this->assertSame('1', $settings->get('k2')->getIdentifier());
+        $this->assertTrue($settings->get('k2')->getIsDefaultValue());
     }
 
     /**
@@ -61,9 +63,11 @@ class SettingsFactoryTest extends TestCase
         $this->assertSame('k1', $settings->get('k1')->getKey());
         $this->assertSame('o1', $settings->get('k1')->getValue());
         $this->assertSame('1', $settings->get('k1')->getIdentifier());
+        $this->assertFalse($settings->get('k1')->getIsDefaultValue());
         $this->assertSame('k2', $settings->get('k2')->getKey());
         $this->assertSame('v2', $settings->get('k2')->getValue());
         $this->assertSame('1', $settings->get('k2')->getIdentifier());
+        $this->assertTrue($settings->get('k1')->getIsDefaultValue());
     }
 
     /**
@@ -96,8 +100,10 @@ class SettingsFactoryTest extends TestCase
         $this->assertSame('k1', $settings->get('k1')->getKey());
         $this->assertSame('o1', $settings->get('k1')->getValue());
         $this->assertSame('1', $settings->get('k1')->getIdentifier());
+        $this->assertFalse($settings->get('k1')->getIsDefaultValue());
         $this->assertSame('k2', $settings->get('k2')->getKey());
         $this->assertSame('o2', $settings->get('k2')->getValue());
         $this->assertSame('1', $settings->get('k2')->getIdentifier());
+        $this->assertFalse($settings->get('k2')->getIsDefaultValue());
     }
 }


### PR DESCRIPTION
added a boolean `isDefaultValue` to the Setting Object, which is exactly what it means - true if this Setting is the default, false if it is based off of an Override (even if it's the same value as the default)